### PR TITLE
feat: add prevButtonAccessibilityLabel and nextButtonAccessibilityLab…

### DIFF
--- a/src/components/header/next-button.tsx
+++ b/src/components/header/next-button.tsx
@@ -36,6 +36,7 @@ const NextButton = ({
     calendarView,
     components = {},
     isRTL,
+    nextButtonAccessibilityLabel = 'Next',
   } = useCalendarContext();
 
   const colorScheme = useColorScheme();
@@ -70,7 +71,7 @@ const NextButton = ({
       onPress={onPress}
       testID="btn-next"
       accessibilityRole="button"
-      accessibilityLabel="Next"
+      accessibilityLabel={nextButtonAccessibilityLabel}
     >
       <View
         style={[defaultStyles.iconContainer, defaultStyles.next, style]}

--- a/src/components/header/prev-button.tsx
+++ b/src/components/header/prev-button.tsx
@@ -36,6 +36,7 @@ const PrevButton = ({
     onChangeYear,
     components = {},
     isRTL,
+    prevButtonAccessibilityLabel = 'Prev',
   } = useCalendarContext();
 
   const colorScheme = useColorScheme();
@@ -70,7 +71,7 @@ const PrevButton = ({
       onPress={onPress}
       testID="btn-prev"
       accessibilityRole="button"
-      accessibilityLabel="Prev"
+      accessibilityLabel={prevButtonAccessibilityLabel}
     >
       <View
         style={[defaultStyles.iconContainer, defaultStyles.prev, style]}

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -115,6 +115,8 @@ const DateTimePicker = (
     onMonthChange = () => {},
     onYearChange = () => {},
     use12Hours,
+    prevButtonAccessibilityLabel,
+    nextButtonAccessibilityLabel,
   } = props;
 
   dayjs.tz.setDefault(timeZone);
@@ -639,6 +641,8 @@ const DateTimePicker = (
       style,
       className,
       use12Hours,
+      prevButtonAccessibilityLabel,
+      nextButtonAccessibilityLabel,
     }),
     [
       mode,
@@ -669,6 +673,8 @@ const DateTimePicker = (
       style,
       className,
       use12Hours,
+      prevButtonAccessibilityLabel,
+      nextButtonAccessibilityLabel,
     ]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,8 @@ export interface DatePickerBaseProps {
   dates?: DateType[];
   min?: number;
   max?: number;
+  prevButtonAccessibilityLabel?: string;
+  nextButtonAccessibilityLabel?: string;
   onChange?: SingleChange | RangeChange | MultiChange;
   startYear?: number;
   endYear?: number;


### PR DESCRIPTION
Add prevButtonAccessibilityLabel and nextButtonAccessibilityLabel props to DatePickerBaseProps, allowing consumers to override the default "Prev" / "Next" accessibility labels on the calendar navigation buttons.

This is useful for apps that need localized or context-specific accessibility labels to comply with screen reader requirements.

Changes:

types.ts — add prevButtonAccessibilityLabel?: string and nextButtonAccessibilityLabel?: string to DatePickerBaseProps
datetime-picker.tsx — forward both props through the calendar context value
prev-button.tsx — consume prevButtonAccessibilityLabel from context (default: 'Prev')
next-button.tsx — consume nextButtonAccessibilityLabel from context (default: 'Next')